### PR TITLE
[deps] Use the new `extendible` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ are made readable and which one's are writable.
 
 This allows you to add `Backbone` inspired `.extend` functionality to your
 constructors. This makes inheriting a lot easier and readable. See the
-`extendable` module in npm for information.
+`extendible` module in npm for information.
 
 ```js
 function Foo() {}

--- a/index.js
+++ b/index.js
@@ -296,7 +296,7 @@ function merge(target, additional) {
 //
 // Attach some convenience functions.
 //
-predefine.extend = require('extendable');
+predefine.extend = require('extendible');
 predefine.descriptor = descriptor;
 predefine.create = create;
 predefine.remove = remove;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Arnout Kazemier",
   "license": "MIT",
   "dependencies": {
-    "extendable": "0.0.x"
+    "extendible": "0.1.x"
   },
   "devDependencies": {
     "pre-commit": "0.0.x",


### PR DESCRIPTION
This suppresses the warning stating that `extendable` is deprecated in favor of `extendible`.
