### PR TITLE
fix: Address prototype pollution vulnerability in merge function

### DIFF
--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ function merge(target, additional) {
     each(additional, function objectForEach(key, value) {
       if (target[key] === undefined) {
         result[key] = value;
-      } else {
+      } else if (Object.hasOwnProperty.call(target, key)){
         result[key] = merge(target[key], additional[key]);
       }
     });

--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ function merge(target, additional) {
     each(additional, function objectForEach(key, value) {
       if (target[key] === undefined) {
         result[key] = value;
-      } else if (Object.hasOwnProperty.call(target, key)){
+      } else if (has.call(target, key)) {
         result[key] = merge(target[key], additional[key]);
       }
     });

--- a/test.js
+++ b/test.js
@@ -181,4 +181,12 @@ describe('predefine', function () {
       assume(calls).to.equal(1);
     });
   });
+
+  describe('.merge', function () {
+    it('avoids prototype polluting', function () {
+      predefine.merge({}, JSON.parse('{"__proto__": {"a": "b"}}'));
+
+      assume(({}).a).to.be.undefined();
+   });
+  });
 });


### PR DESCRIPTION
I have verified that this lib's `merge` function has a [Prototype Pollution vulnerability in predefine](https://snyk.io/vuln/SNYK-JS-PREDEFINE-1054935).

The vulnerable code: https://github.com/bigpipe/predefine/blob/0.1.2/index.js#L263-L294

PoC (Before):
```javascript
const predefine = require('predefine');
predefine.merge({}, JSON.parse('{"__proto__": {"a": "b"}}'));

console.log(({}).a === 'b' ? 'exploitable' : 'unexploitable'); // exploitable
```

This PR edits the vulnerable place, and adds a test to make sure it is unexploiable.